### PR TITLE
Security: Dependabot findings.

### DIFF
--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -21,8 +21,9 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 18
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'corretto'
           java-version: 18
       - uses: actions/cache@v1
         with:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -39,7 +39,7 @@
         <org.mapstruct.version>1.3.1.Final</org.mapstruct.version>
         <springdoc.version>2.0.2</springdoc.version>
         <maven.test.skip>false</maven.test.skip>
-        <log4j.version>2.18.0</log4j.version>
+        <log4j.version>2.20.0</log4j.version>
     </properties>
 
     <dependencies>
@@ -158,17 +158,12 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.8.0</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.15</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>pdfbox</artifactId>
-            <version>2.0.26</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
@@ -209,7 +204,7 @@
                 <plugin>
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
-                    <version>6.1.1.Final</version>
+                    <version>6.6.4.Final</version>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
@@ -293,7 +288,7 @@
                     <plugin>
                         <groupId>org.hibernate.orm.tooling</groupId>
                         <artifactId>hibernate-enhance-maven-plugin</artifactId>
-                        <version>6.1.1.Final</version>
+                        <version>6.6.4.Final</version>
                         <executions>
                             <execution>
                                 <configuration>


### PR DESCRIPTION

Change Details:
- Bump org.hibernate.orm.tooling:hibernate-enhance-maven-plugin from 6.1.1.Final to 6.6.4.Final 
- Bump commons-io:commons-io from 2.8.0 to 2.18.0 
- Bump actions/setup-java from 1 to 4 
- Bump aquasecurity/trivy-action from 0.2.5 to 0.29.0 
- Bump docker/login-action from 1 to 3 
- Bump actions/github-script from 5 to 7 
- Bump github/codeql-action from 2 to 3 
- Bump log4j.version from 2.18.0 to 2.19.0 [Made change to sync to 2.20.0]